### PR TITLE
Declare Node 22 and Homebridge 2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "homebridge-bed-control",
-      "version": "1.3.3",
+      "version": "1.3.8",
       "funding": [
         {
           "type": "github",
@@ -44,8 +44,8 @@
         "typescript-eslint": "^7.13.0"
       },
       "engines": {
-        "homebridge": "^1.8.0",
-        "node": "^18.17.0 || ^20.9.0"
+        "homebridge": "^1.8.0 || ^2.0.0",
+        "node": "^18.17.0 || ^20.9.0 || ^22.14.0 || ^24.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/hbblebc/homebridge-bed-control/issues"
   },
   "engines": {
-    "node": "^18.17.0 || ^20.9.0",
-    "homebridge": "^1.8.0"
+    "node": "^18.17.0 || ^20.9.0 || ^22.14.0 || ^24.0.0",
+    "homebridge": "^1.8.0 || ^2.0.0"
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Updates the package engine metadata to include the Homebridge 2 / Node 22+ runtime line while preserving existing Node 18 and Node 20 support.\n\nThis is metadata-only: package name/version and runtime code are unchanged. I also synced the root package-lock version with package.json while rebuilding locally.